### PR TITLE
Update Github workflows and JVM version

### DIFF
--- a/.github/workflows/azure.yml
+++ b/.github/workflows/azure.yml
@@ -2,7 +2,7 @@ name: Deploy to Azure Functions
 
 env:
   AZURE_WEBAPP_NAME: your-app-name    # set this to the name of your Azure Web App
-  JAVA_VERSION: '11'                  # set this to the Java version to use
+  JAVA_VERSION: '17'                  # set this to the Java version to use
   DISTRIBUTION: zulu                  # set this to the Java distribution
 
 on:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,11 +1,3 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
 name: Java CI with Maven
 
 env:
@@ -39,7 +31,3 @@ jobs:
           
     - name: Build with Maven
       run: mvn clean package
-
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6


### PR DESCRIPTION
In line with the project's move to Java 17, the authenticated Github workflows (maven.yml and azure.yml) have been streamlined. Redundant comments and the dependency graph update step have been removed from maven.yml for simplification. In azure.yml, the java version specified for the Azure WebApp has been updated from '11' to '17'. This commit helps to keep our workflows up-to-date and optimized for the new Java version.